### PR TITLE
Fix singleton type only

### DIFF
--- a/Cheryl.Uno/Controls/SliverPageLong.cs
+++ b/Cheryl.Uno/Controls/SliverPageLong.cs
@@ -108,7 +108,7 @@ public class OffsetToInvertOpacityConverterLong : IValueConverter
 
 public class OffsetToFontSizeConverterLong : IValueConverter
 {
-    public static readonly OffsetToInvertOpacityConverterLong Instance = new OffsetToInvertOpacityConverterLong();
+    public static readonly OffsetToFontSizeConverterLong Instance = new OffsetToFontSizeConverterLong();
 
     public object Convert(object value, Type targetType, object parameter, string language)
     {


### PR DESCRIPTION
## Summary
- revert opacity converter value change so it returns a bool again
- leave the fixed `Instance` singleton type for `OffsetToFontSizeConverterLong`

## Testing
- `dotnet build CherylUI.Uno.Demo.sln -clp:ErrorsOnly;summary` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_b_68593764b36083329eb14da4bbc7017b